### PR TITLE
Msg 增加 extra_area

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/msg.md
+++ b/docs/msg.md
@@ -11,6 +11,8 @@ type|string|success|有效的icon名|icon类型
 title | string|||标题
 description|string|||描述
 buttons|array| [ ]| | 底部操作按钮，至少包含label属性
+extraText | string | | | 额外内容
+extraHref | string | | | 额外内容链接
 
 buttons的描述示例如下：
 
@@ -31,6 +33,6 @@ import WeUI from 'react-weui';
 const {Msg} = WeUI;
 
 ReactDOM.render((
-    <Msg type="success" title="提交成功" description="你的反馈我们已经收到" />
+    <Msg type="success" title="提交成功" description="你的反馈我们已经收到" extraText="查看详情" extraHref="#"/>
 ), document.getElementById('container'));
 ```

--- a/example/pages/msg/index.js
+++ b/example/pages/msg/index.js
@@ -29,7 +29,7 @@ export default class MsgDemo extends React.Component {
     render() {
         return (
             <Page className="msg" title="Msg" spacing>
-                <Msg type="success" title="提交成功" description="你的反馈我们已经收到" buttons={this.state.buttons} />
+                <Msg type="success" title="提交成功" description="你的反馈我们已经收到" buttons={this.state.buttons} extraText="查看详情" extraHref="#"/>
             </Page>
         );
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "eslint": "^1.10.3",
         "eslint-plugin-react": "^3.11.3",
         "file-loader": "^0.8.5",
-        "history": "1.13.1",
         "istanbul": "^0.4.1",
         "less": "^2.5.3",
         "less-loader": "^2.2.1",

--- a/src/components/msg/msg.js
+++ b/src/components/msg/msg.js
@@ -49,8 +49,8 @@ class Msg extends React.Component {
                 <div className="weui_extra_area">
                     {
                         this.props.extraHref ?
-                            <a href={this.props.extraHref}>{this.props.extraText}</a> :
-                            <p>{this.props.extraText}</p>
+                            <a href={this.props.extraHref} className="weui_extra_link">{this.props.extraText}</a> :
+                            <p className="weui_extra_text">{this.props.extraText}</p>
                     }
                 </div>
             </div>

--- a/src/components/msg/msg.js
+++ b/src/components/msg/msg.js
@@ -46,6 +46,13 @@ class Msg extends React.Component {
                         {this._renderButtons()}
                     </p>
                 </div>
+                <div className="weui_extra_area">
+                    {
+                        this.props.extraHref ?
+                            <a href={this.props.extraHref}>{this.props.extraText}</a> :
+                            <p>{this.props.extraText}</p>
+                    }
+                </div>
             </div>
         );
     }

--- a/test/msg.js
+++ b/test/msg.js
@@ -63,5 +63,29 @@ describe('<Msg></Msg>', ()=> {
             });
 
         });
+        describe(`<Msg extraText="${extraText}" />`, ()=> {
+            const wrapper = shallow(
+                <Msg extraText={extraText} />
+            );
+
+            it(`should have extra text "${extraText}"`, ()=> {
+                const $extraArea = wrapper.find('.weui_extra_text').shallow();
+                assert($extraArea.text() === extraText)
+            })
+        });
+
+        describe(`<Msg extraText="${extraText}" extraHref="${extraHref}"/>`, ()=> {
+            const wrapper = shallow(
+                <Msg extraText={extraText} extraHref={extraHref}/>
+            );
+            const $extraArea = wrapper.find('.weui_extra_link').shallow();
+
+            it(`should have extra link text "${extraText}"`, ()=> {
+                assert($extraArea.text() === extraText)
+            })
+            it(`should have extra link href "${extraHref}"`, ()=> {
+                assert($extraArea.prop('href') === extraHref)
+            })
+        });
     });
 });

--- a/test/msg.js
+++ b/test/msg.js
@@ -22,6 +22,8 @@ describe('<Msg></Msg>', ()=> {
             console.log('ok');
         }
     }];
+    const extraText = '查看详情';
+    const extraHref = '#';
 
     ['success', 'info', 'waiting', 'warn'].map((type) => {
         describe(`<msg type="${type}"></msg>`, ()=> {
@@ -59,6 +61,7 @@ describe('<Msg></Msg>', ()=> {
                     assert($button.hasClass(`weui_btn_${buttons[index].type}`));
                 });
             });
+
         });
     });
 });


### PR DESCRIPTION
1. 给 `Msg` 增加了 extra_area 部分，通过传入 `extraText` 和 `extraHref` 两个参数来使用。
1. 增加了相应的测试样例。
1. 增加了相应的文档。
1. 增加了 `.editorconfig`。
1. 删除不必要的依赖 `history`。

PS：初次运行 `npm install` 的时候出错了：
```
npm ERR! peerinvalid The package history@1.13.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router@1.0.3 wants history@^1.17.0
```
看了一下发现 `packge.json` 中指定了 `history` 的版本为 `1.13.1`，而 [`react-router` 需要大于 `1.17.0` 的版本](https://github.com/rackt/react-router/blob/1.0.x/package.json#L44)。我不清除这里依赖引用的优先级是怎么样的，不过删掉这个依赖就不会报错了。而且其他地方没有直接依赖 `history` ，所以删掉后不会有影响。