### PR TITLE
update react version and move to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "homepage": "https://github.com/weui/react-weui",
     "dependencies": {
         "classnames": "^2.2.0",
-        "react": "^0.14.2"
     },
     "devDependencies": {
         "autoprefixer": "^6.3.5",
@@ -67,5 +66,8 @@
         "webpack": "^1.12.2",
         "webpack-dev-server": "^1.12.1",
         "weui": "^0.4.1"
+    },
+    "peerDependencies": {
+        "react": "^0.14.2 || ^15.0.1"
     }
 }


### PR DESCRIPTION
1. `react` 升级到 v15，并且引入了新的版本规范。
    @see https://facebook.github.io/react/blog/2016/02/19/new-versioning-scheme.html

2. 不同版本的 `react` 会冲突，把依赖写到 `peerDependencies` 更合适一点。参考其他
    `react` 相关的库，如 `react-redux`.