### PR TITLE
Update toast.md icon="loading"

### DIFF
--- a/docs/toast.md
+++ b/docs/toast.md
@@ -5,7 +5,7 @@
 
 属性 | 类型 | 默认值 | 可选值 | 备注
 -----|------|--------|-------|------|
-icon|string|toast|所有icon| 
+icon|string|toast|所有icon / loading | 
 iconSize|string|'small'|small, large| icon size
 show|bool|false|| 是否显示 
 


### PR DESCRIPTION
weui 和 react-weui 都实现了 loading,不知道为什么文档上都没有提到

个人在使用 react-weui 想用 loading 的时候查看文档[Icon](https://github.com/weui/react-weui/blob/master/docs/icon.md)未发现 loading，阅读源码才看到实现了 icon='loading' 的

loading 添加到 icon 文档似乎不那么合理，故把 loading 提出来，避免其他人不用 `<Toast icon="loaing"/> `而去weui上扣结构模拟 loading