### PR TITLE
箭头函数不需要手动绑定

### DIFF
--- a/src/components/form/uploader.js
+++ b/src/components/form/uploader.js
@@ -115,7 +115,7 @@ export default class Uploader extends React.Component {
                             drawImage.call(ctx, img, sx, sy, sw, sh / vertSquashRatio);
                         else
                             drawImage.call(ctx, img, sx, sy);
-                    }.bind(this);
+                    };
 
                     canvas.width = w;
                     canvas.height = h;


### PR DESCRIPTION
 去掉 箭头函数后面的  bind(this)