### PR TITLE
修复 页面过渡动画结束时，home页闪现bug

### DIFF
--- a/example/component/page.less
+++ b/example/component/page.less
@@ -57,7 +57,7 @@ body {
         }
         &.page-leave {
             &.page-leave-active {
-                opacity: 1;
+                opacity: 0;
                 transform: translate3d(0, 0, 0);
             }
         }


### PR DESCRIPTION
bug现象：页面切换过渡动画完成后，home页会闪现一次
原因 ：home页在leave后的CSS状态中，透明度应该为0