### PR TITLE
remove findDOMNode from searchbar

### DIFF
--- a/src/components/searchbar/searchbar.js
+++ b/src/components/searchbar/searchbar.js
@@ -84,7 +84,11 @@ class SearchBar extends React.Component {
 
         this.setState({text: '', clearing: true});
         if(this.props.onClear) this.props.onClear(e);
-        ReactDOM.findDOMNode(this.refs.searchInput).focus()
+        // In most cases, you can attach a ref to the DOM node and avoid using findDOMNode at all. 
+        // When render returns null or false, findDOMNode returns null.
+        // 这里是截取官网的说明，在ref回调函数内确实会返回null，尤其是配合redux使用的时候，这个时候需要对其进行null判断
+        this.refs.searchInput.focus();
+        // ReactDOM.findDOMNode(this.refs.searchInput).focus()
         if(this.props.onChange) this.props.onChange('',e);
     }
 
@@ -134,7 +138,12 @@ class SearchBar extends React.Component {
                     </div>
                     <label
                         className='weui-search-bar__label'
-                        onClick={e=>ReactDOM.findDOMNode(this.refs.searchInput).focus()}
+                        onClick={()=>{
+                            let searchInput = this.refs.searchInput;
+                            if (searchInput) {
+                                searchInput.focus();
+                            }
+                        }}
                         style={{display: this.state.text ? 'none': null}}
                     >
                         <Icon value='search'/>


### PR DESCRIPTION
在官网的描述中有如下的描述，官网也不是建议使用这个api，而在配合redux使用的时候，findDOMNode会有返回null的情况(在ref回调中，这里在onclick应该是没问题的)。但是本身searchInput已经存在于this.refs中了。因此没必要再使用findDOMNode了。
```
ReactDOM.findDOMNode(component)
If this component has been mounted into the DOM, this returns the corresponding native browser DOM element. This method is useful for reading values out of the DOM, such as form field values and performing DOM measurements. In most cases, you can attach a ref to the DOM node and avoid using findDOMNode at all. When render returns null or false, findDOMNode returns null.
```