### PR TITLE
fix <component> init error

### DIFF
--- a/src/components/flex/flex_item.js
+++ b/src/components/flex/flex_item.js
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
  *
  */
 const FlexItem = (props) => {
-    const { component, children, ...others } = props;
+    const { component: Component, children, ...others } = props;
     return (
-        <component className="weui-flex__item" {...others}>
+        <Component className="weui-flex__item" {...others}>
             { children }
-        </component>
+        </Component>
     );
 };
 


### PR DESCRIPTION
> Warning: The tag <component> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.